### PR TITLE
Fix potential deadlock.

### DIFF
--- a/Immense.SimpleMessenger.Tests/WeakReferenceMessengerTests.cs
+++ b/Immense.SimpleMessenger.Tests/WeakReferenceMessengerTests.cs
@@ -1,6 +1,3 @@
-using Immense.SimpleMessenger;
-using System.Diagnostics;
-
 namespace Immense.SimpleMessenger.Tests;
 
 [TestClass]

--- a/Immense.SimpleMessenger/Immense.SimpleMessenger.csproj
+++ b/Immense.SimpleMessenger/Immense.SimpleMessenger.csproj
@@ -16,7 +16,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 	<Company>Immense Networks</Company>
-	<Version>1.1.0</Version>
+	<Version>1.2.0</Version>
 	<AssemblyVersion>$(Version)</AssemblyVersion>
 	<FileVersion>$(Version)</FileVersion>
   </PropertyGroup>

--- a/Immense.SimpleMessenger/Internals/CompositeKey.cs
+++ b/Immense.SimpleMessenger/Internals/CompositeKey.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Immense.SimpleMessenger.Internals;
+﻿namespace Immense.SimpleMessenger.Internals;
 
 /// <summary>
 /// A dictionary key composed of the message type and channel type.

--- a/Immense.SimpleMessenger/Internals/DefaultChannel.cs
+++ b/Immense.SimpleMessenger/Internals/DefaultChannel.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Immense.SimpleMessenger.Internals;
+﻿namespace Immense.SimpleMessenger.Internals;
 internal readonly struct DefaultChannel : IEquatable<DefaultChannel>
 {
     private static readonly int _hashCode =

--- a/Immense.SimpleMessenger/Internals/HandlerRegistration.cs
+++ b/Immense.SimpleMessenger/Internals/HandlerRegistration.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Immense.SimpleMessenger.Internals;
+internal class HandlerRegistration<TMessageType, TChannelType> : IAsyncDisposable
+    where TMessageType : class
+    where TChannelType : IEquatable<TChannelType>
+{
+    private WeakReferenceTable? _table;
+    private object? _subscriber;
+
+    public HandlerRegistration(WeakReferenceTable table, object subscriber)
+    {
+        _table = table;
+        _subscriber = subscriber;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_table is not null && _subscriber is not null)
+        {
+            await _table.Remove(_subscriber);
+        }
+
+        // We want to allow the subscriber to be GCed, even if something
+        // still has a reference to this disposed instance.
+        _subscriber = null;
+        _table = null;
+    }
+}

--- a/Immense.SimpleMessenger/Internals/HandlerRegistration.cs
+++ b/Immense.SimpleMessenger/Internals/HandlerRegistration.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Immense.SimpleMessenger.Internals;
 
-namespace Immense.SimpleMessenger.Internals;
 internal class HandlerRegistration<TMessageType, TChannelType> : IAsyncDisposable
     where TMessageType : class
     where TChannelType : IEquatable<TChannelType>

--- a/Immense.SimpleMessenger/Internals/Result.cs
+++ b/Immense.SimpleMessenger/Internals/Result.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
-using System.Text;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 namespace Immense.SimpleMessenger.Internals;
 

--- a/Immense.SimpleMessenger/Internals/WeakReferenceTable.cs
+++ b/Immense.SimpleMessenger/Internals/WeakReferenceTable.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Runtime.CompilerServices;
 
 namespace Immense.SimpleMessenger.Internals;
 


### PR DESCRIPTION
Changes:

- Prevent potential deadlock in `Send` method by moving invocation of handlers outside of the semaphore lock for the registrations.
- `Register` now returns an `IAsyncDisposable` that will unregister the handler when disposed.
- The error list returned by `Send` is now immutable.
- Added a `CancellationToken` parameter to `Send`.